### PR TITLE
fix multiple attribute replacement issue while cleaning the content

### DIFF
--- a/lib/htmllint-loader.js
+++ b/lib/htmllint-loader.js
@@ -19,16 +19,16 @@ const cleanContent = (content) => {
   const lines = content.split('\n');
 
   for (let [i, line] of lines.entries()) {
-    line = line.replace(/="{{.*}}"/, '="temp"');
-    line = line.replace(/="{{{.*}}}"/, '="temp"');
+    line = line.replace(/="{{.*?}}"/, '="temp"');
+    line = line.replace(/="{{{.*?}}}"/, '="temp"');
     line = line.replace('<?php', '    ');
     line = line.replace('<?=', '   ');
     line = line.replace('<?', '  ');
     line = line.replace('<%', '  ');
     line = line.replace('%>', '  ');
     line = line.replace('?>', '  ');
-    line = line.replace(/{{.*}}/g, '');
-    line = line.replace(/{{{.*}}}/g, '');
+    line = line.replace(/{{.*?}}/g, '');
+    line = line.replace(/{{{.*?}}}/g, '');
     lines[i] = line;
   }
 


### PR DESCRIPTION
The current implementation of cleanContent function replaces the line:
`<img src='{{imgSrc}}' alt='{{imgAlt}}' title='{{imgTitle}}' height='18px'/>`
with:
`<img src='' height='18px'/>`

This pull request fixes this issue.