### PR TITLE
Updates htmllint to version 0.6.0

### DIFF
--- a/dist/config.js
+++ b/dist/config.js
@@ -8,7 +8,7 @@ var defaultOptions = exports.defaultOptions = {
   'attr-name-ignore-regex': false,
   'attr-name-style': 'dash',
   'attr-no-dup': true,
-  'attr-no-unsafe-chars': true,
+  'attr-no-unsafe-char': true,
   'attr-quote-style': 'double',
   'attr-req-value': true,
   'class-no-dup': true,

--- a/lib/config.js
+++ b/lib/config.js
@@ -21,7 +21,7 @@ export const defaultOptions = {
   'attr-name-ignore-regex': false,
   'attr-name-style': 'dash',
   'attr-no-dup': true,
-  'attr-no-unsafe-chars': true,
+  'attr-no-unsafe-char': true,
   'attr-quote-style': 'double',
   'attr-req-value': true,
   'class-no-dup': true,

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "deasync": "^0.1.9",
     "fs-extra": "^1.0.0",
     "html-tags": "^1.1.1",
-    "htmllint": "^0.4.0",
+    "htmllint": "^0.6.0",
     "loader-utils": "^0.2.16",
     "lodash": "^4.17.2",
     "text-table": "^0.2.0"


### PR DESCRIPTION
Updates htmllint to 0.6.0, and updates config option which was incorrect. The
`attr-no-unsafe-char` option should not have an "s" at the end.